### PR TITLE
Update build-time dependency on NumPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ license = { "file" = "LICENSE.md" }
 dependencies = [
   # Lower bounds for deps are as in scikit-learn in May 2024, 1.6.dev0
   "joblib>=1.2.0",
-  "numpy>=1.19.5",
+  "numpy>=1.19.5,<2",
   "scipy>=1.6.0"
 ]
 dynamic = ["version", "readme"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ homepage = "https://surpriselib.com"
 repository = "https://github.com/NicolasHug/Surprise"
 
 [build-system]
-requires = ["setuptools>=61.0.0", "wheel", "Cython>=3.0.10", "oldest-supported-numpy"]
+requires = ["setuptools>=61.0.0", "wheel", "Cython>=3.0.10", "numpy>=1.19.5,<2"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.dynamic]

--- a/surprise/prediction_algorithms/co_clustering.pyx
+++ b/surprise/prediction_algorithms/co_clustering.pyx
@@ -7,7 +7,6 @@ the :mod:`co_clustering` module includes the :class:`CoClustering` algorithm.
 
 cimport numpy as np  # noqa
 import numpy as np
-from numpy cimport ndarray
 
 from .algo_base import AlgoBase
 from ..utils import get_rng
@@ -74,19 +73,19 @@ class CoClustering(AlgoBase):
         AlgoBase.fit(self, trainset)
 
         # User and item means
-        cdef ndarray[np.double_t] user_mean
-        cdef ndarray[np.double_t] item_mean
+        cdef np.ndarray[np.double_t] user_mean
+        cdef np.ndarray[np.double_t] item_mean
 
         # User and items clusters
-        cdef ndarray[np.int_t] cltr_u
-        cdef ndarray[np.int_t] cltr_i
+        cdef np.ndarray[np.int_t] cltr_u
+        cdef np.ndarray[np.int_t] cltr_i
 
         # Average rating of user clusters, item clusters and co-clusters
-        cdef ndarray[np.double_t] avg_cltr_u
-        cdef ndarray[np.double_t] avg_cltr_i
-        cdef ndarray[np.double_t, ndim=2] avg_cocltr
+        cdef np.ndarray[np.double_t] avg_cltr_u
+        cdef np.ndarray[np.double_t] avg_cltr_i
+        cdef np.ndarray[np.double_t, ndim=2] avg_cocltr
 
-        cdef ndarray[np.double_t] errors
+        cdef np.ndarray[np.double_t] errors
         cdef int u, i, r, uc, ic
         cdef double est
 
@@ -155,8 +154,8 @@ class CoClustering(AlgoBase):
 
         return self
 
-    def compute_averages(self, ndarray[np.int_t] cltr_u,
-                         ndarray[np.int_t] cltr_i):
+    def compute_averages(self, np.ndarray[np.int_t] cltr_u,
+                         np.ndarray[np.int_t] cltr_i):
         """Compute cluster averages.
 
         Args:
@@ -169,19 +168,19 @@ class CoClustering(AlgoBase):
         """
 
         # Number of entities in user clusters, item clusters and co-clusters.
-        cdef ndarray[np.int_t] count_cltr_u
-        cdef ndarray[np.int_t] count_cltr_i
-        cdef ndarray[np.int_t, ndim=2] count_cocltr
+        cdef np.ndarray[np.int_t] count_cltr_u
+        cdef np.ndarray[np.int_t] count_cltr_i
+        cdef np.ndarray[np.int_t, ndim=2] count_cocltr
 
         # Sum of ratings for entities in each cluster
-        cdef ndarray[np.int_t] sum_cltr_u
-        cdef ndarray[np.int_t] sum_cltr_i
-        cdef ndarray[np.int_t, ndim=2] sum_cocltr
+        cdef np.ndarray[np.int_t] sum_cltr_u
+        cdef np.ndarray[np.int_t] sum_cltr_i
+        cdef np.ndarray[np.int_t, ndim=2] sum_cocltr
 
         # The averages of each cluster (what will be returned)
-        cdef ndarray[np.double_t] avg_cltr_u
-        cdef ndarray[np.double_t] avg_cltr_i
-        cdef ndarray[np.double_t, ndim=2] avg_cocltr
+        cdef np.ndarray[np.double_t] avg_cltr_u
+        cdef np.ndarray[np.double_t] avg_cltr_i
+        cdef np.ndarray[np.double_t, ndim=2] avg_cocltr
 
         cdef int u, i, r, uc, ic
         cdef double global_mean = self.trainset.global_mean

--- a/surprise/prediction_algorithms/co_clustering.pyx
+++ b/surprise/prediction_algorithms/co_clustering.pyx
@@ -7,6 +7,7 @@ the :mod:`co_clustering` module includes the :class:`CoClustering` algorithm.
 
 cimport numpy as np  # noqa
 import numpy as np
+from numpy cimport ndarray
 
 from .algo_base import AlgoBase
 from ..utils import get_rng
@@ -73,19 +74,19 @@ class CoClustering(AlgoBase):
         AlgoBase.fit(self, trainset)
 
         # User and item means
-        cdef np.ndarray[np.double_t] user_mean
-        cdef np.ndarray[np.double_t] item_mean
+        cdef ndarray[np.double_t] user_mean
+        cdef ndarray[np.double_t] item_mean
 
         # User and items clusters
-        cdef np.ndarray[np.int_t] cltr_u
-        cdef np.ndarray[np.int_t] cltr_i
+        cdef ndarray[np.int_t] cltr_u
+        cdef ndarray[np.int_t] cltr_i
 
         # Average rating of user clusters, item clusters and co-clusters
-        cdef np.ndarray[np.double_t] avg_cltr_u
-        cdef np.ndarray[np.double_t] avg_cltr_i
-        cdef np.ndarray[np.double_t, ndim=2] avg_cocltr
+        cdef ndarray[np.double_t] avg_cltr_u
+        cdef ndarray[np.double_t] avg_cltr_i
+        cdef ndarray[np.double_t, ndim=2] avg_cocltr
 
-        cdef np.ndarray[np.double_t] errors
+        cdef ndarray[np.double_t] errors
         cdef int u, i, r, uc, ic
         cdef double est
 
@@ -154,8 +155,8 @@ class CoClustering(AlgoBase):
 
         return self
 
-    def compute_averages(self, np.ndarray[np.int_t] cltr_u,
-                         np.ndarray[np.int_t] cltr_i):
+    def compute_averages(self, ndarray[np.int_t] cltr_u,
+                         ndarray[np.int_t] cltr_i):
         """Compute cluster averages.
 
         Args:
@@ -168,19 +169,19 @@ class CoClustering(AlgoBase):
         """
 
         # Number of entities in user clusters, item clusters and co-clusters.
-        cdef np.ndarray[np.int_t] count_cltr_u
-        cdef np.ndarray[np.int_t] count_cltr_i
-        cdef np.ndarray[np.int_t, ndim=2] count_cocltr
+        cdef ndarray[np.int_t] count_cltr_u
+        cdef ndarray[np.int_t] count_cltr_i
+        cdef ndarray[np.int_t, ndim=2] count_cocltr
 
         # Sum of ratings for entities in each cluster
-        cdef np.ndarray[np.int_t] sum_cltr_u
-        cdef np.ndarray[np.int_t] sum_cltr_i
-        cdef np.ndarray[np.int_t, ndim=2] sum_cocltr
+        cdef ndarray[np.int_t] sum_cltr_u
+        cdef ndarray[np.int_t] sum_cltr_i
+        cdef ndarray[np.int_t, ndim=2] sum_cocltr
 
         # The averages of each cluster (what will be returned)
-        cdef np.ndarray[np.double_t] avg_cltr_u
-        cdef np.ndarray[np.double_t] avg_cltr_i
-        cdef np.ndarray[np.double_t, ndim=2] avg_cocltr
+        cdef ndarray[np.double_t] avg_cltr_u
+        cdef ndarray[np.double_t] avg_cltr_i
+        cdef ndarray[np.double_t, ndim=2] avg_cocltr
 
         cdef int u, i, r, uc, ic
         cdef double global_mean = self.trainset.global_mean


### PR DESCRIPTION
The failed tests happen in build time. so I tried to update the build time requirements, and it worked!
I suspect it may have something to do with the [oldest-supported-numpy](https://pypi.org/project/oldest-supported-numpy/) package used for building surprise.

See also the test results in my PR: https://github.com/SimonYansenZhao/Surprise/pull/1